### PR TITLE
一部の MPP 環境で周期 IDR フレームが先頭1回しか出力されない問題を修正

### DIFF
--- a/mppcore/mpp_pipeline.h
+++ b/mppcore/mpp_pipeline.h
@@ -1892,6 +1892,26 @@ public:
         //auto meta = mpp_frame_get_meta(mppframe);
         //mpp_meta_set_packet(meta, KEY_OUTPUT_PACKET, packet);
 
+        // rk_mppの内部 rc.gop (igop) 経由での周期 IDR は、MPP/ファームウェアのバージョンによって
+        // 先頭1回しか発行されない場合がある。ffmpeg-rockchip と同様に、明示的に
+        // MPP_ENC_SET_IDR_FRAME を発行することで周期性を保証する。
+        //   - EOS フレームには発行しない
+        //   - poc == 0 (先頭フレーム) は MPP が自動的に IDR を発行するのでスキップ
+        //   - --gop-len auto (gop == 0) の時は MPP 側に委ねるため何もしない
+        //   - H.264 / HEVC のみ対象 (MJPEG には IDR の概念はない)
+        if (!mppframeeos && (m_encCodec == RGY_CODEC_H264 || m_encCodec == RGY_CODEC_HEVC)) {
+            const RK_S32 gop = m_encParams.rc.gop;
+            const RK_S32 poc = (RK_S32)mpp_frame_get_poc(mppframe);
+            if (gop > 0 && poc > 0 && (poc % gop) == 0) {
+                auto idr_ret = err_to_rgy(m_encoder->mpi->control(m_encoder->ctx, MPP_ENC_SET_IDR_FRAME, nullptr));
+                if (idr_ret != RGY_ERR_NONE) {
+                    PrintMes(RGY_LOG_WARN, _T("Failed to force IDR frame at poc %d (gop %d): %s.\n"), poc, gop, get_err_mes(idr_ret));
+                } else {
+                    PrintMes(RGY_LOG_DEBUG, _T("Forced periodic IDR frame at poc %d (gop %d).\n"), poc, gop);
+                }
+            }
+        }
+
         auto err = RGY_ERR_NONE;
         bool sendFrame = false;
         do {


### PR DESCRIPTION
## 概要

`--gop-len` で指定した周期での IDR フレーム出力が、一部の MPP ライブラリ／ファームウェアの組み合わせにおいて先頭 1 回しか発行されない問題を修正いたしました。

## 発生経緯

本問題は、rkmppenc を [KonomiTV](https://github.com/tsukumijima/KonomiTV) の録画番組再生用エンコーダーとして利用した際、**録画ファイルの映像がまったく再生されない**現象に遭遇したことが発端でございます。

KonomiTV は録画再生時、エンコード出力を HLS セグメントに分割しながら配信する実装（biim ベース）となっており、**各セグメントの区切りに IDR フレームを必要とします**。そのため、先頭以降に周期的な IDR が出力されないと 2 つ目以降のセグメントを生成できず、再生が先頭で停止してしまいます。

調査の結果、この現象の原因が rkmppenc 側の周期 IDR 出力にあることが判明いたしましたので、以下のとおり修正いたしました。

## 背景

現在の実装では、`mpp_core.cpp::initEncoderRC` にて `m_enccfg.rc.gop = prm->gopLen` を `MPP_ENC_SET_RC_CFG` 経由で MPP に渡し、周期 IDR の生成を MPP 内部の igop 機構に委ねております。

しかし実際には、以下のような条件下において igop が期待どおり機能せず、先頭 1 回の IDR 以降は周期的な IDR が発行されない現象を確認いたしました。

- MPP の develop 版において `MPP_ENC_SET_RC_CFG` が deprecated 扱いとなり `MPP_NOK` を返すようになった
- 一部のファームウェア／SoC において `rc.gop` 経由の igop 設定が内部に反映されない

本現象は、`--gop-len` の値や `--avsync vfr`（`--vfr`）の有無に関わらず発生いたします。

## 調査内容

同じく Rockchip MPP を利用している [nyanmisaka/ffmpeg-rockchip](https://github.com/nyanmisaka/ffmpeg-rockchip) の `libavcodec/rkmppenc.c` では、周期 IDR を `rc.gop` 単独に依存せず、各フレーム投入前に `MPP_ENC_SET_IDR_FRAME` 制御コマンドを明示的に発行することで本問題を回避しております。

MPP 側の実装（`mpp/codec/mpp_enc_impl.c`）において、`MPP_ENC_SET_IDR_FRAME` は以下のとおり、`rc.gop`（igop）経由の経路とは独立した強制 IDR 経路となっております。

```c
case MPP_ENC_SET_IDR_FRAME : {
    enc->frm_cfg.force_flag |= ENC_FORCE_IDR;
    enc->frm_cfg.force_idr++;
} break;
```

同コマンドはいかなる MPP バージョンにおいても deprecated 化されておらず、常に有効な即時制御

## 修正内容

`mppcore/mpp_pipeline.h` の `PipelineTaskMPPEncode::sendFrame` 内、`encode_put_frame` 呼び 御を追加いたしました。

追加した動作は以下のとおりです。

- H.264 / HEVC のみを対象とする（MJPEG に IDR の概念はないため）
- `--gop-len auto`（`gopLen == 0`）の場合は従来どおり MPP 側に委ね、何も行わない（後方互換のため）
- `poc % gopLen == 0` かつ `poc > 0` のフレームに対して `MPP_ENC_SET_IDR_FRAME` を発行する
  - `poc == 0`（先頭フレーム）は MPP が自動的に IDR を発行するためスキップする（二重 IDR の回避）
- EOS フレームには適用しない

## テスト方法（ご参考）

```
rkmppenc --avhw -i <input> -c h264 --gop-len 50 --repeat-headers -o out.h264
ffprobe -show_frames out.h264 | grep -c key_frame=1
```

修正前は `key_frame=1` が 1 のみ、修正後は期待どおり「総フレーム数 ÷ gopLen」程度の件数になることを確認しております。